### PR TITLE
Clean up SDL.h includes

### DIFF
--- a/src/game/SDLMain.m
+++ b/src/game/SDLMain.m
@@ -5,7 +5,7 @@
     Feel free to customize this file to suit your needs
 */
 
-#include "SDL/SDL.h"
+#include "SDL.h"
 #include "SDLMain.h"
 #include <sys/param.h> /* for MAXPATHLEN */
 #include <unistd.h>

--- a/src/game/ai/predictive_ai.hpp
+++ b/src/game/ai/predictive_ai.hpp
@@ -1,11 +1,7 @@
 #ifndef LIERO_PREDICTIVE_AI_HPP
 #define LIERO_PREDICTIVE_AI_HPP
 
-#ifdef WIN32
 #include <SDL.h>
-#else
-#include <SDL2/SDL.h>
-#endif // WIN32
 
 #include "../worm.hpp"
 #include "../math.hpp"

--- a/src/game/ai/work_queue.hpp
+++ b/src/game/ai/work_queue.hpp
@@ -1,11 +1,7 @@
 #ifndef LIERO_WORK_QUEUE_HPP
 #define LIERO_WORK_QUEUE_HPP
 
-#ifdef WIN32
 #include <SDL.h>
-#else
-#include <SDL2/SDL.h>
-#endif // WIN32
 #include <sstream>
 #include <vector>
 #include "tl/memory.h"

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1,8 +1,4 @@
-#ifdef WIN32
 #include <SDL.h>
-#else
-#include <SDL2/SDL.h>
-#endif // WIN32
 #include <cstdlib>
 #include <ctime>
 

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -1,10 +1,5 @@
-#ifdef WIN32
 #include <SDL.h>
 #include <SDL_image.h>
-#else
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
-#endif // WIN32
 #include <cstring>
 #include <cassert>
 #include <cstdlib>

--- a/src/game/gfx.hpp
+++ b/src/game/gfx.hpp
@@ -1,11 +1,7 @@
 #ifndef LIERO_GFX_HPP
 #define LIERO_GFX_HPP
 
-#ifdef WIN32
 #include <SDL.h>
-#else
-#include <SDL2/SDL.h>
-#endif // WIN32
 #include <gvl/resman/shared_ptr.hpp>
 #include <gvl/math/rect.hpp>
 

--- a/src/game/keys.cpp
+++ b/src/game/keys.cpp
@@ -1,8 +1,4 @@
-#ifdef WIN32
 #include <SDL.h>
-#else
-#include <SDL2/SDL.h>
-#endif // WIN32
 #include <cstddef>
 #include <cassert>
 #include <map>

--- a/src/game/keys.hpp
+++ b/src/game/keys.hpp
@@ -1,11 +1,7 @@
 #ifndef UUID_96141CB1E20547016970B28195515A14
 #define UUID_96141CB1E20547016970B28195515A14
 
-#ifdef WIN32
 #include <SDL.h>
-#else
-#include <SDL2/SDL.h>
-#endif // WIN32
 
 //extern int SDLToLieroKeys[SDL_SCANCODE_LAST];
 //extern int lieroToSDLKeys[177];

--- a/src/game/main.cpp
+++ b/src/game/main.cpp
@@ -1,11 +1,7 @@
 #ifndef UUID_DC1D9513CDD34960AB8A648004DA149D
 #define UUID_DC1D9513CDD34960AB8A648004DA149D
 
-#ifdef WIN32
 #include <SDL.h>
-#else
-#include <SDL2/SDL.h>
-#endif // WIN32
 
 #include "gfx.hpp"
 #include "sfx.hpp"

--- a/src/game/menu/menu.hpp
+++ b/src/game/menu/menu.hpp
@@ -1,11 +1,7 @@
 #ifndef UUID_3DC24B15AD67494EEAB541B4AE253D0F
 #define UUID_3DC24B15AD67494EEAB541B4AE253D0F
 
-#ifdef WIN32
 #include <SDL.h>
-#else
-#include <SDL2/SDL.h>
-#endif // WIN32
 #include <cstddef>
 #include <string>
 #include <cstdio>

--- a/src/game/sfx.cpp
+++ b/src/game/sfx.cpp
@@ -5,11 +5,7 @@
 #include <vector>
 #include <cassert>
 #if !DISABLE_SOUND
-#ifdef WIN32
 #	include <SDL.h>
-#	else
-#	include <SDL2/SDL.h>
-#	endif // WIN32
 #endif
 
 Sfx sfx;

--- a/src/game/weapsel.cpp
+++ b/src/game/weapsel.cpp
@@ -1,8 +1,4 @@
-#ifdef WIN32
 #include <SDL.h>
-#else
-#include <SDL2/SDL.h>
-#endif // WIN32
 
 #include "weapsel.hpp"
 #include "gfx.hpp"


### PR DESCRIPTION
The SDL2_INCLUDE_DIR CMake variable is the directory that contains
SDL.h, so specifying SDL2/SDL.h is redundant and causes errors if the
compiler doesn't search by default in the directory that contains SDL2
(such as /usr/local/include).
