### PR TITLE
Fix playing the wrong sound on death

### DIFF
--- a/src/game/worm.cpp
+++ b/src/game/worm.cpp
@@ -413,7 +413,7 @@ void Worm::process(Game& game)
 					game.soundPlayer->stop(&weapons[currentWeapon]);
 				}
 				
-				int deathSnd = 16 + game.rand(3);
+				int deathSnd = 15 + game.rand(3);
 				game.soundPlayer->play(deathSnd, this);
 				
 				fireCone = 0;


### PR DESCRIPTION
The original Liero 1.33 executable used to play 3 different sounds.
Five years ago, I had been playing with the new version with Liero ProMode TC, and noticed that one of the sounds was clearly not being played.

Today I debugged it, and it turned out to be an off-by-one error (playing "death2", "death3", "hurt1", instead of "death1", "death2", "death3")